### PR TITLE
Use ':utf8' for pipe in the Perl script template.

### DIFF
--- a/template/perl/base-script.pl
+++ b/template/perl/base-script.pl
@@ -1,5 +1,7 @@
 use strict;
 use warnings;
 use utf8;
+binmode STDIN, ':utf8';
+binmode STDOUT, ':utf8';
 
 {{_cursor_}}


### PR DESCRIPTION
Thank you for your nice plugin.

I think that Perl often is used UTF-8 for STDIN, STDOUT these years, so the template might want to set the option as default, might not?

Thanks.