### PR TITLE
Allow user to disable mapping completely

### DIFF
--- a/plugin/sonictemplate.vim
+++ b/plugin/sonictemplate.vim
@@ -1,7 +1,7 @@
 "=============================================================================
 " File: sonictemplate.vim
 " Author: Yasuhiro Matsumoto <mattn.jp@gmail.com>
-" Last Change: 01-May-2013.
+" Last Change: 25-Nov-2020.
 " Version: 0.10
 " WebPage: http://github.com/mattn/sonictemplate-vim
 " Description: Easy and high speed coding method
@@ -24,8 +24,8 @@ exe 'command!' '-nargs=1' '-complete=customlist,sonictemplate#complete' get(g:, 
 
 nnoremap <plug>(sonictemplate) :call sonictemplate#select('n')<cr>
 inoremap <plug>(sonictemplate) <c-r>=sonictemplate#select('i')<cr>
-if !hasmapto('<plug>(sonictemplate)')
-  if get(g:, 'sonictemplate_key', '') == ''
+if !hasmapto('<plug>(sonictemplate)') && get(g:, 'sonictemplate_key', 1) != ''
+  if empty(get(g:, 'sonictemplate_key'))
     nmap <unique> <c-y>t <plug>(sonictemplate)
     imap <unique> <expr> <c-y>t pumvisible()?'<c-e><plug>(sonictemplate)':'<plug>(sonictemplate)'
     nmap <unique> <c-y><c-t> <c-y>t
@@ -38,8 +38,8 @@ endif
 
 nnoremap <plug>(sonictemplate-intelligent) :call sonictemplate#select_intelligent('n')<cr>
 inoremap <plug>(sonictemplate-intelligent) <c-r>=sonictemplate#select_intelligent('i')<cr>
-if !hasmapto('<plug>(sonictemplate-intelligent)')
-  if get(g:, 'sonictemplate_intelligent_key') == ''
+if !hasmapto('<plug>(sonictemplate-intelligent)') && get(g:, 'sonictemplate_intelligent_key', 1) != ''
+  if empty(get(g:, 'sonictemplate_intelligent_key'))
     nmap <unique> <c-y>T <plug>(sonictemplate-intelligent)
     imap <unique> <expr> <c-y>T pumvisible()?'<c-e><plug>(sonictemplate-intelligent)':'<plug>(sonictemplate-intelligent)'
   else
@@ -49,8 +49,8 @@ if !hasmapto('<plug>(sonictemplate-intelligent)')
 endif
 
 inoremap <plug>(sonictemplate-postfix) <c-r>=sonictemplate#postfix()<cr>
-if !hasmapto('<plug>(sonictemplate-postfix)')
-  if get(g:, 'sonictemplate_postfix_key', '') == ''
+if !hasmapto('<plug>(sonictemplate-postfix)') && get(g:, 'sonictemplate_postfix_key', 1) != ''
+  if empty(get(g:, 'sonictemplate_postfix_key'))
     imap <unique> <expr> <c-y><c-b> pumvisible()?'<c-e><plug>(sonictemplate-postfix)':'<plug>(sonictemplate-postfix)'
   else
     exe 'imap' g:sonictemplate_postfix_key '<plug>(sonictemplate-postfix)'


### PR DESCRIPTION
Allow user to disable key mappings completely, i.e.
```vim
let g:sonictemplate_key = 0
let g:sonictemplate_intelligent_key = 0
let g:sonictemplate_postfix_key = 0
```

This allows me to consume & use templates in other ways e.g. completion menu.